### PR TITLE
PR #5 Review.

### DIFF
--- a/src/xcustom.h
+++ b/src/xcustom.h
@@ -23,16 +23,95 @@
 #define CAT_(A, B) A ## B
 #define CAT(A, B) CAT_(A, B)
 
+/** Assembly macro for creating "raw" Rocket Custom Coproessor (RoCC)
+  * assembly language instructions that will return data in rd. These
+  * are to be used only in assembly language programs (not C/C++).
+  *
+  * Example:
+  *
+  * Consider the following macro consisting of a CUSTOM_0 instruction
+  * with func7 "42" that is doing some operation of "a0 = op(a1, a2):
+  *
+  *     ROCC_INSTRUCTION_RAW_R_R_R(0, a0, a1, a2, 42)
+  *
+  * This will produce the following pseudo assembly language
+  * instruction:
+  *
+  *     .insn r CUSTOM_0, 7, 42, a0, a1, a2
+  *
+  * @param x the custom instruction number: 0, 1, 2, or 3
+  * @param rd the destination register, e.g., a0 or x10
+  * @param rs1 the first source register, e.g., a0 or x10
+  * @param rs2 the second source register, e.g., a0 or x10
+  * @param func7 the value of the func7 field
+  * @return a raw .insn RoCC instruction
+  */
 #define ROCC_INSTRUCTION_RAW_R_R_R(x, rd, rs1, rs2, func7) \
   .insn r CAT(CUSTOM_, x), 7, func7, rd, rs1, rs2
 
+/** Assembly macro for creating "raw" Rocket Custom Coproessor (RoCC)
+  * assembly language instructions that will *NOT* return data in rd.
+  * These are to be used only in assembly language programs (not
+  * C/C++).
+  *
+  * Example:
+  *
+  * Consider the following macro consisting of a CUSTOM_1 instruction
+  * with func7 "42" that is doing some operation of "op(a1, a2). *NO*
+  * data is returned:
+  *
+  *     ROCC_INSTRUCTION_RAW_R_R_R(1, a1, a2, 42)
+  *
+  * This will produce the following pseudo assembly language
+  * instruction:
+  *
+  *     .insn r CUSTOM_1, 3, 42, x0, a1, a2
+  *
+  * @param x the custom instruction number: 0, 1, 2, or 3
+  * @param rs1 the first source register, e.g., a0 or x10
+  * @param rs2 the second source register, e.g., a0 or x10
+  * @param func7 the value of the func7 field
+  * @return a raw .insn RoCC instruction
+  */
 #define ROCC_INSTRUCTION_RAW_0_R_R(x, rs1, rs2, func7) \
   .insn r CAT(CUSTOM_, x), 3, func7, x0, rs1, rs2
 
 
+/** C/C++ inline assembly macro for creating Rocket Custom Coprocessor
+  * (RoCC) instructions that return data in rd. These are to be used
+  * only in C/C++ programs (not bare assembly).
+  *
+  * This is equivalent to ROCC_INSTRUCTION_R_R_R. See it's
+  * documentation.
+  */
 #define ROCC_INSTRUCTION(x, rd, rs1, rs2, func7) \
   ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)
 
+/** C/C++ inline assembly macro for creating Rocket Custom Coprocessor
+  * (RoCC) instructions that return data in rd. These are to be used
+  * only in C/C++ programs (not bare assembly).
+  *
+  * Example:
+  *
+  * Consider the following macro consisting of a CUSTOM_2 instruction
+  * with func7 "42" that is doing some operation of "a0 = op(a1, a2):
+  *
+  *     ROCC_INSTRUCTION(2, a0, a1, a2, 42)
+  *
+  * This will produce the following inline assembly:
+  *
+  *     asm volatile(
+  *         ".insn r CUSTOM_2, 0x7, 42, %0, %1, %2"
+  *         : "=r"(rd)
+  *         : "r"(rs1), "r"(rs2));
+  *
+  * @param x the custom instruction number: 0, 1, 2, or 3
+  * @param rd the destination register, e.g., a0 or x10
+  * @param rs1 the first source register, e.g., a0 or x10
+  * @param rs2 the second source register, e.g., a0 or x10
+  * @param func7 the value of the func7 field
+  * @return an inline assembly RoCC instruction
+  */
 #define ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)                 \
   {                                                                     \
     asm volatile(                                                       \
@@ -41,6 +120,29 @@
         : "r"(rs1), "r"(rs2));                                          \
   }
 
+/** C/C++ inline assembly macro for creating Rocket Custom Coprocessor
+  * (RoCC) instructions that return data in rd. These are to be used
+  * only in C/C++ programs (not bare assembly).
+  *
+  * Example:
+  *
+  * Consider the following macro consisting of a CUSTOM_3 instruction
+  * with func7 "42" that is doing some operation of "a0 = op(a1, a2):
+  *
+  *     ROCC_INSTRUCTION(3, a0, a1, a2, 42)
+  *
+  * This will produce the following inline assembly:
+  *
+  *     asm volatile(
+  *         ".insn r CUSTOM_3, 0x7, 42, %0, %1, %2"
+  *         :: "r"(rs1), "r"(rs2));
+  *
+  * @param x the custom instruction number: 0, 1, 2, or 3
+  * @param rs1 the first source register, e.g., a0 or x10
+  * @param rs2 the second source register, e.g., a0 or x10
+  * @param funct7 the value of the funct7 f
+  * @return an inline assembly RoCC instruction
+  */
 #define ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, func7)                     \
   {                                                                     \
     asm volatile(                                                       \

--- a/src/xcustom.h
+++ b/src/xcustom.h
@@ -1,4 +1,4 @@
-// Copyright 2018 IBM
+// Copyright 2018--2020 IBM
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/xcustom.h
+++ b/src/xcustom.h
@@ -20,7 +20,7 @@
 #define STR(x) STR1(x)
 #endif
 
-#define CAT_(A, B) A ## B
+#define CAT_(A, B) A##B
 #define CAT(A, B) CAT_(A, B)
 
 /** Assembly macro for creating "raw" Rocket Custom Coproessor (RoCC)
@@ -30,7 +30,7 @@
   * Example:
   *
   * Consider the following macro consisting of a CUSTOM_0 instruction
-  * with func7 "42" that is doing some operation of "a0 = op(a1, a2):
+  * with func7 "42" that is doing some operation of "a0 = op(a1, a2)":
   *
   *     ROCC_INSTRUCTION_RAW_R_R_R(0, a0, a1, a2, 42)
   *
@@ -57,7 +57,7 @@
   * Example:
   *
   * Consider the following macro consisting of a CUSTOM_1 instruction
-  * with func7 "42" that is doing some operation of "op(a1, a2). *NO*
+  * with func7 "42" that is doing some operation of "op(a1, a2)". *NO*
   * data is returned:
   *
   *     ROCC_INSTRUCTION_RAW_R_R_R(1, a1, a2, 42)
@@ -76,7 +76,6 @@
 #define ROCC_INSTRUCTION_RAW_0_R_R(x, rs1, rs2, func7) \
   .insn r CAT(CUSTOM_, x), 3, func7, x0, rs1, rs2
 
-
 /** C/C++ inline assembly macro for creating Rocket Custom Coprocessor
   * (RoCC) instructions that return data in rd. These are to be used
   * only in C/C++ programs (not bare assembly).
@@ -88,13 +87,14 @@
   ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)
 
 /** C/C++ inline assembly macro for creating Rocket Custom Coprocessor
-  * (RoCC) instructions that return data in rd. These are to be used
-  * only in C/C++ programs (not bare assembly).
+  * (RoCC) instructions that return data in C variable rd. 
+  * These are to be used only in C/C++ programs (not bare assembly).
   *
   * Example:
   *
   * Consider the following macro consisting of a CUSTOM_2 instruction
-  * with func7 "42" that is doing some operation of "a0 = op(a1, a2):
+  * with func7 "42" that is doing some operation of "a0 = op(a1, a2)"
+  * (where a0, a1, and a2 are variables defined in C):
   *
   *     ROCC_INSTRUCTION(2, a0, a1, a2, 42)
   *
@@ -106,28 +106,29 @@
   *         : "r"(rs1), "r"(rs2));
   *
   * @param x the custom instruction number: 0, 1, 2, or 3
-  * @param rd the destination register, e.g., a0 or x10
-  * @param rs1 the first source register, e.g., a0 or x10
-  * @param rs2 the second source register, e.g., a0 or x10
+  * @param rd the C variable to capture as destination operand
+  * @param rs1 the C variable to capture for first source register
+  * @param rs2 the C variable to capture for second source register
   * @param func7 the value of the func7 field
   * @return an inline assembly RoCC instruction
   */
-#define ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)                 \
-  {                                                                     \
-    asm volatile(                                                       \
+#define ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)                               \
+  {                                                                                  \
+    asm volatile(                                                                    \
         ".insn r " STR(CAT(CUSTOM_, x)) ", " STR(0x7) ", " STR(func7) ", %0, %1, %2" \
-        : "=r"(rd)                                                      \
-        : "r"(rs1), "r"(rs2));                                          \
+        : "=r"(rd)                                                                   \
+        : "r"(rs1), "r"(rs2));                                                       \
   }
 
 /** C/C++ inline assembly macro for creating Rocket Custom Coprocessor
-  * (RoCC) instructions that return data in rd. These are to be used
-  * only in C/C++ programs (not bare assembly).
+  * (RoCC) instructions that return data in C variable rd.
+  * These are to be used only in C/C++ programs (not bare assembly).
   *
   * Example:
   *
   * Consider the following macro consisting of a CUSTOM_3 instruction
-  * with func7 "42" that is doing some operation of "a0 = op(a1, a2):
+  * with func7 "42" that is doing some operation of "a0 = op(a1, a2)"
+  * (where a0, a1, and a2 are variables defined in C):
   *
   *     ROCC_INSTRUCTION(3, a0, a1, a2, 42)
   *
@@ -138,16 +139,17 @@
   *         :: "r"(rs1), "r"(rs2));
   *
   * @param x the custom instruction number: 0, 1, 2, or 3
-  * @param rs1 the first source register, e.g., a0 or x10
-  * @param rs2 the second source register, e.g., a0 or x10
+  * @param rs1 the C variable to capture for first source register
+  * @param rs2 the C variable to capture for second source register
   * @param funct7 the value of the funct7 f
   * @return an inline assembly RoCC instruction
   */
-#define ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, func7)                     \
-  {                                                                     \
-    asm volatile(                                                       \
+#define ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, func7)                                   \
+  {                                                                                  \
+    asm volatile(                                                                    \
         ".insn r " STR(CAT(CUSTOM_, x)) ", " STR(0x3) ", " STR(func7) ", x0, %0, %1" \
-        :: "r"(rs1), "r"(rs2));                                         \
+        :                                                                            \
+        : "r"(rs1), "r"(rs2));                                                       \
   }
 
 // [TODO] fix these to align with the above approach

--- a/src/xcustom.h
+++ b/src/xcustom.h
@@ -20,31 +20,32 @@
 #define STR(x) STR1(x)
 #endif
 
-#define XCUSTOM_OPCODE(x) XCUSTOM_OPCODE_##x
-#define XCUSTOM_OPCODE_0 0b0001011
-#define XCUSTOM_OPCODE_1 0b0101011
-#define XCUSTOM_OPCODE_2 0b1011011
-#define XCUSTOM_OPCODE_3 0b1111011
+#define CAT_(A, B) A ## B
+#define CAT(A, B) CAT_(A, B)
 
-// Standard macro that passes rd, rs1, and rs2 via registers
-#define ROCC_INSTRUCTION(x, rd, rs1, rs2, funct7) \
-  ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, funct7)
+#define ROCC_INSTRUCTION_RAW_R_R_R(x, rd, rs1, rs2, func7) \
+  .insn r CAT(CUSTOM_, x), 7, func7, rd, rs1, rs2
 
-// rd, rs1, and rs2 are data
-#define ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, funct7)                                 \
-  {                                                                                     \
-    asm volatile(                                                                       \
-        ".insn r " STR(XCUSTOM_OPCODE(x)) ", " STR(0x3) ", " STR(funct7) ", %0, %1, %2" \
-        : "=r"(rd)                                                                      \
-        : "r"(rs1), "r"(rs2));                                                          \
+#define ROCC_INSTRUCTION_RAW_0_R_R(x, rs1, rs2, func7) \
+  .insn r CAT(CUSTOM_, x), 3, func7, x0, rs1, rs2
+
+
+#define ROCC_INSTRUCTION(x, rd, rs1, rs2, func7) \
+  ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)
+
+#define ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)                 \
+  {                                                                     \
+    asm volatile(                                                       \
+        ".insn r " STR(CAT(CUSTOM_, x)) ", " STR(0x7) ", " STR(func7) ", %0, %1, %2" \
+        : "=r"(rd)                                                      \
+        : "r"(rs1), "r"(rs2));                                          \
   }
 
-#define ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, funct7)                                     \
-  {                                                                                     \
-    asm volatile(                                                                       \
-        ".insn r " STR(XCUSTOM_OPCODE(x)) ", " STR(0x3) ", " STR(funct7) ", x0, %0, %1" \
-        :                                                                               \
-        : "r"(rs1), "r"(rs2));                                                          \
+#define ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, func7)                     \
+  {                                                                     \
+    asm volatile(                                                       \
+        ".insn r " STR(CAT(CUSTOM_, x)) ", " STR(0x3) ", " STR(func7) ", x0, %0, %1" \
+        :: "r"(rs1), "r"(rs2));                                         \
   }
 
 // [TODO] fix these to align with the above approach


### PR DESCRIPTION
This is doing the following things:

1. The `*_RAW_*` instructions are needed for pure assembly language tests. See: [`seldridge/rocket-rocc-examples`](https://github.com/seldridge/rocket-rocc-examples/blob/master/bareMetal/accumulator.S#L17). I added this back in using your great approach.
1. The `xd` bit in the `func3` field should be asserted if `rd` is something that the RoCC is supposed to return. This was incorrectly set to `0x3` unconditionally and should be `0x7` sometimes. 
1. I realized that binutils actually supports `CUSTOM_0` and friends for the opcode. There's no need for us to manually encode this. ([Search in this diff for `CUSTOM_` to see what I mean.](https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commitdiff;h=0e35537d754f1c687850d1caccb2d78d2e418391;hp=3ae9ce5dd7d1119ca2c94c63a07b04921048ebe3))
1. Added Scaladoc-style documentation to everything
1. Bumped the copyright

I've been testing this with `rocket-rocc-examples` and the bare metal example works. I don't have a patched proxy kernel, but I'm fine to YOLO that. It would be nice if I had CI for all this...

I'm good to merge #5 with these changes.